### PR TITLE
Get rid of `strict` in the jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,5 @@
 	"newcap": true,
 	"noarg": true,
 	"undef": true,
-	"unused": "vars",
-	"strict": true
+	"unused": "vars"
 }


### PR DESCRIPTION
It’s implied in ES6 modules. See <http://stackoverflow.com/q/22730514/2816199>.