### PR TITLE
added dec and inc with tests and documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ PRs are welcome!
   - [bitAnd](#bitand)
   - [bitOr](#bitor)
   - [xor](#xor)
+  - [inc](#inc)
+  - [dec](#dec)
   - [compose](#compose)
   - [pipe](#pipe)
   - [curry1,2,3,4](#curry1234)
@@ -176,6 +178,28 @@ var xor = require('1-liners/xor');
 
 xor(0, 1); // => 1
 xor(1, 1); // => 0
+```
+
+### inc
+
+Increment a value by one (default) or more.
+
+```js
+var inc = require('1-liners/inc');
+
+inc(1); // => 2
+inc(2, 8); // => 10
+```
+
+### dec
+
+Decrement a value by one (default) or more.
+
+```js
+var dec = require('1-liners/dec');
+
+dec(1); // => 0
+dec(10, 2); // => 8
 ```
 
 ### compose

--- a/src/dec.js
+++ b/src/dec.js
@@ -1,0 +1,1 @@
+export default (val, decrement=1) => val - decrement;

--- a/src/inc.js
+++ b/src/inc.js
@@ -1,0 +1,1 @@
+export default (val, increment=1) => val + increment;

--- a/tests/dec.js
+++ b/tests/dec.js
@@ -1,0 +1,7 @@
+import { equal } from 'assert';
+import dec from '../dec';
+
+test('#dec', () => {
+	equal(dec(5), 4);
+	equal(dec(5,5), 0);
+});

--- a/tests/inc.js
+++ b/tests/inc.js
@@ -1,0 +1,7 @@
+import { equal } from 'assert';
+import inc from '../inc';
+
+test('#inc', () => {
+	equal(inc(0), 1);
+	equal(inc(0,5), 5);
+});


### PR DESCRIPTION
Each can take an optional value to adjust how much the returned value should inc'd or dec'd by. So `inc(1,-1)` is the same as `dec(1)`. I'm a little uncertain about it but I think the optional value could be useful, let me know what you think.