### PR TITLE
Add new function `flip`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ PRs are welcome!
   - [compose](#compose)
   - [pipe](#pipe)
   - [curry1,2,3,4](#curry1234)
+  - [flip](#flip)
   - [apply](#apply)
   - [noop](#noop)
   - [ifElse](#ifelse)
@@ -240,6 +241,19 @@ var curry4 = require('1-liners/curry4');
 let f = (a, b, c) => a + b + c;
 var fC = curry3(f);
 fC(1)(2)(3); // => 6
+```
+
+### flip
+
+Flip a function’s arguments.
+
+```js
+var flip = require('1-liners/flip');
+
+var f = (a, b) => a / b;
+
+flip(f)(2, 6);        // => 3
+flip(flip(f))(6, 2);  // => 3
 ```
 
 ### apply

--- a/src/flip.js
+++ b/src/flip.js
@@ -1,0 +1,1 @@
+export default (f) => (...args) => f(...args.reverse());

--- a/tests/flip.js
+++ b/tests/flip.js
@@ -1,0 +1,12 @@
+import { equal } from 'assert';
+import flip from '../flip';
+
+test('#flip', () => {
+  const f = (a, b) => a / b;
+  equal(flip(f)(2, 6), 3);
+  equal(flip(flip(f))(6, 2), 3);
+
+  const g = (a, b, c) => a / (b + c);
+  equal(flip(g)(1, 2, 3), 1);
+  equal(flip(flip(g))(3, 2, 1), 1);
+});

--- a/tests/flip.js
+++ b/tests/flip.js
@@ -2,11 +2,11 @@ import { equal } from 'assert';
 import flip from '../flip';
 
 test('#flip', () => {
-  const f = (a, b) => a / b;
-  equal(flip(f)(2, 6), 3);
-  equal(flip(flip(f))(6, 2), 3);
-
-  const g = (a, b, c) => a / (b + c);
-  equal(flip(g)(1, 2, 3), 1);
-  equal(flip(flip(g))(3, 2, 1), 1);
+	const f = (a, b) => a / b;
+	equal(flip(f)(2, 6), 3);
+	equal(flip(flip(f))(6, 2), 3);
+	
+	const g = (a, b, c) => a / (b + c);
+	equal(flip(g)(1, 2, 3), 1);
+	equal(flip(flip(g))(3, 2, 1), 1);
 });


### PR DESCRIPTION
### flip

Flip a function’s arguments.

```js
var flip = require(1-liners/flip);

var f = (a, b) => a / b;

flip(f)(2, 6);        // => 3
flip(flip(f))(6, 2);  // => 3
```