### PR TITLE
Add `property` and `method`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ PRs are welcome!
   - [some](#some)
   - [join](#join)
   - [split](#split)
+  - [property](#property)
+  - [method](#method)
 - [Maintainers](#maintainers)
 - [License](#license)
 
@@ -437,6 +439,33 @@ Same as `'1-liners'.split('-')`
 var split = require('1-liners/split');
 
 split('-', '1-liners'); // => [1, 'liners']
+```
+
+### property
+
+Same as `object.property`
+
+```js
+const property = require('1-liners/property');
+
+const object = {foo: 1};
+
+property('foo', object);  // => 1
+```
+
+### method
+
+Same as `object.method(...args)`
+
+```js
+const method = require('1-liners/method');
+
+const object = {
+	base: 1,
+	add(number) { return this.base + number; },
+};
+
+method('add', object)(5);  // => 6
 ```
 
 

--- a/module/method.js
+++ b/module/method.js
@@ -1,0 +1,1 @@
+export default (method, object) => (...args) => object[method](...args);

--- a/module/property.js
+++ b/module/property.js
@@ -1,0 +1,1 @@
+export default (property, object) => object[property];

--- a/tests/method.js
+++ b/tests/method.js
@@ -1,0 +1,14 @@
+import { equal } from 'assert';
+import method from '../method';
+
+test('#method', () => {
+	const object = {
+		base: 1,
+		add(number) { return this.base + number; },
+	};
+
+	equal(
+		method('add', object)(5),
+		6
+	);
+});

--- a/tests/property.js
+++ b/tests/property.js
@@ -1,0 +1,10 @@
+import { equal } from 'assert';
+import property from '../property';
+
+test('#property', () => {
+	const object = {foo: 1, baz: [3]};
+
+	equal(property('foo', object), 1);
+	equal(property('bar', object), undefined);
+	equal(property('baz', object), object.baz);
+});


### PR DESCRIPTION
To <https://github.com/stoeffel/1-liners/issues/1#issuecomment-97926822>:

### property

Same as `object.property`

```js
const property = require(1-liners/property);

const object = {foo: 1};

property(foo, object);  // => 1
```

### method

Same as `object.method(...args)`

```js
const method = require(1-liners/method);

const object = {
base: 1,
add(number) { return this.base + number; },
};

method(add, object)(5);  // => 6
```

WIP.