### PR TITLE
Add `min` and `max`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ PRs are welcome!
   - [bitAnd](#bitand)
   - [bitOr](#bitor)
   - [xor](#xor)
+  - [min](#min)
+  - [max](#max)
   - [inc](#inc)
   - [dec](#dec)
   - [compose](#compose)
@@ -186,6 +188,26 @@ var xor = require('1-liners/xor');
 
 xor(0, 1); // => 1
 xor(1, 1); // => 0
+```
+
+### min
+
+Same as `Math.min` – but with a stable number of arguments.
+
+```js
+var min = require('1-liners/min');
+
+min(3, 6);  // => 3
+```
+
+### max
+
+Same as `Math.max` – but with a stable number of arguments.
+
+```js
+var max = require('1-liners/max');
+
+max(3, 6);  // => 6
 ```
 
 ### inc

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ Same as `Math.min` – but with a stable number of arguments.
 var min = require('1-liners/min');
 
 min(3, 6);  // => 3
+
+[3, 6, 1].reduce(min);       // => 1
+[3, 6, 1].reduce(Math.min);  // => NaN
 ```
 
 ### max
@@ -208,6 +211,9 @@ Same as `Math.max` – but with a stable number of arguments.
 var max = require('1-liners/max');
 
 max(3, 6);  // => 6
+
+[3, 6, 9].reduce(max);       // => 9
+[3, 6, 9].reduce(Math.max);  // => NaN
 ```
 
 ### inc

--- a/module/max.js
+++ b/module/max.js
@@ -1,0 +1,1 @@
+export default (a, b) => ((a > b) ? a : b);

--- a/module/min.js
+++ b/module/min.js
@@ -1,0 +1,1 @@
+export default (a, b) => ((a > b) ? b : a);

--- a/tests/max.js
+++ b/tests/max.js
@@ -3,5 +3,7 @@ import max from '../max';
 
 test('#max', () => {
 	equal(max(3, 6), 6);
+	equal(max(6, 3), 6);
+
 	equal([3, 6, 9].reduce(max), 9);
 });

--- a/tests/max.js
+++ b/tests/max.js
@@ -1,0 +1,7 @@
+import {equal} from 'assert';
+import max from '../max';
+
+test('#max', () => {
+	equal(max(3, 6), 6);
+	equal([3, 6, 9].reduce(max), 9);
+});

--- a/tests/min.js
+++ b/tests/min.js
@@ -3,5 +3,7 @@ import min from '../min';
 
 test('#min', () => {
 	equal(min(3, 6), 3);
+	equal(min(6, 3), 3);
+
 	equal([3, 6, 1].reduce(min), 1);
 });

--- a/tests/min.js
+++ b/tests/min.js
@@ -1,0 +1,7 @@
+import {equal} from 'assert';
+import min from '../min';
+
+test('#min', () => {
+	equal(min(3, 6), 3);
+	equal([3, 6, 1].reduce(min), 1);
+});


### PR DESCRIPTION
### min

Same as `Math.min` – but with a stable number of arguments.

```js
var min = require('1-liners/min');

min(3, 6);  // => 3
```

### max

Same as `Math.max` – but with a stable number of arguments.

```js
var max = require('1-liners/max');

max(3, 6);  // => 6
```

WIP