### PR TITLE
Add `curryRight2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ PRs are welcome!
   - [pipe](#pipe)
   - [shave](#shave)
   - [curry2,3,4](#curry234)
+  - [curryRight2](#curryright2)
   - [uncurry2,3,4](#uncurry234)
   - [flip](#flip)
   - [implode](#implode)
@@ -373,6 +374,22 @@ const gβ = curry3(g);
 gβ(1)(2)(3, 4);  // => 3
 gβ(1)(2, 3)(4);  // => 3
 gβ(1, 2)(3)(4);  // => 3
+```
+
+### curryRight2
+
+Curry a function from the right – split its parameters into 2 lists. Apply the second list of parameters first, without changing the order within the lists.
+
+```js
+const curryRight2 = require('1-liners/curryRight2');
+
+const g = (a, b, c, d) => a + b * c - d;
+g(1, 2, 3, 4);  // => 3
+
+const gλ = curryRight2(g);
+gλ(4)(1, 2, 3);  // => 3
+gλ(3, 4)(1, 2);  // => 3
+gλ(2, 3, 4)(1);  // => 3
 ```
 
 ### uncurry2,3,4

--- a/module/curryRight2.js
+++ b/module/curryRight2.js
@@ -1,0 +1,1 @@
+export default (f) => (...a) => (...b) => f(...b, ...a);

--- a/module/index.js
+++ b/module/index.js
@@ -6,6 +6,7 @@ import curry1 from './curry1';
 import curry2 from './curry2';
 import curry3 from './curry3';
 import curry4 from './curry4';
+import curryRight2 from './curryRight2';
 import dec from './dec';
 import equal from './equal';
 import every from './every';
@@ -58,6 +59,7 @@ export default {
   curry2,
   curry3,
   curry4,
+  curryRight2,
   dec,
   equal,
   every,

--- a/tests/curryRight2.js
+++ b/tests/curryRight2.js
@@ -1,0 +1,20 @@
+import {equal} from 'assert';
+import curryRight2 from '../curryRight2';
+
+test('#curryRight2', () => {
+	const g = (a, b, c, d) => a + b * c - d;
+	const gλ = curryRight2(g);
+
+	equal(
+		gλ(4)(1, 2, 3),
+		3
+	);
+	equal(
+		gλ(3, 4)(1, 2),
+		3
+	);
+	equal(
+		gλ(2, 3, 4)(1),
+		3
+	);
+});


### PR DESCRIPTION
This is designed for 99% of JS libs – those which export something like `(data1, data2, options = {}) => ...`. You can then do `curryRight2(lib)({my, options})` and have a clean, preconfigured function.

`curryRight3` and `4` are of course possible, but I guess it’d be too complicated to wrap your head around.

***

### curryRight2

Curry a function from the right – split its parameters into 2 lists. Apply the second list of parameters first, without changing the order within the lists.

```js
const curryRight2 = require(1-liners/curryRight2);

const g = (a, b, c, d) => a + b * c - d;
g(1, 2, 3, 4);  // => 3

const gλ = curryRight2(g);
gλ(4)(1, 2, 3);  // => 3
gλ(3, 4)(1, 2);  // => 3
gλ(2, 3, 4)(1);  // => 3
```