### PR TITLE
Switch to named exports

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -48,7 +48,7 @@ import uncurry3 from './uncurry3';
 import uncurry4 from './uncurry4';
 import xor from './xor';
 
-export default {
+export {
   and,
   bitAnd,
   bitOr,

--- a/utils/createIndex.js
+++ b/utils/createIndex.js
@@ -33,7 +33,7 @@ const createExport = reduce(compose, [
 getModules((err, modules) => {
 	if (err) throw err;
 	let imports = createImports(modules);
-	let exportDefault = `export default {\n  ${createExport(modules)}\n};`;
+	let exportDefault = `export {\n  ${createExport(modules)}\n};`;
 	writeFile('./module/index.js', `${imports}\n\n${exportDefault}`, function(err) {
 		if (err) {
 			console.log(err);


### PR DESCRIPTION
I guess `export default {a, b}` and `import {a, b} from '...'` works in *babel*, but it no longer will in proper ES6. After reading http://www.2ality.com/2014/09/es6-modules-final.html I understand that `export {a, b}` is the way to go.

Tell me if I’m wrong :)