### PR TITLE
adds husky and precommit hook :dog:

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
+    "precommit": "npm test; npm run docs;",
+
     "develop": "nodangel --watch module --watch tests --exec 'npm --silent test'",
     "istanbul": "istanbul cover ./node_modules/mocha/bin/_mocha  -- -R nyan --report lcov --compilers js:babel/register --ui qunit ./tests",
     "docs": "babel-node ./utils/createDocs.js; npm run toc;",
@@ -42,6 +44,7 @@
     "coveralls": "^2.11.2",
     "doctoc": "^0.12.0",
     "dox": "^0.7.1",
+    "husky": "^0.7.0",
     "istanbul": "^0.3.13",
     "mocha": "^2.2.4",
     "mocha-lcov-reporter": "0.0.2",


### PR DESCRIPTION
Runs test and docs task before commiting.
After we cleaned up curry and uncurry and all functions are documented we could fail in [npm run docs](https://github.com/stoeffel/1-liners/blob/master/utils/createDocs.js#L60) if a function is missing documentation.

closes #56 